### PR TITLE
Fixed 404 errors when trying to fetch non-latest zlib

### DIFF
--- a/download_zlib.js
+++ b/download_zlib.js
@@ -9,7 +9,7 @@ const TEMP_PATH = 'zlib.tar.gz';
 const ZLIB_VERSION = '1.3.1';
 
 function download(cb) {
-    fetch(`https://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz`)
+    fetch(`https://www.zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz`)
         .then(res => {
             console.log(res.status, res.statusText);
             res.arrayBuffer()


### PR DESCRIPTION
It seems `zlib.net/zlib-VERSION.tar.gz` is only valid for the latest version (1.3.2 as of today).
`zlib.net/fossils/zlib-VERSION.tar.gz` covers all versions including latest.